### PR TITLE
updated Vagrant file for IBM CLI install version

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -80,7 +80,7 @@ Vagrant.configure(2) do |config|
     # Install IBM Cloud CLI as Vagrant user
     sudo -H -u vagrant sh -c 'curl -sL http://ibm.biz/idt-installer | bash'
     sudo -H -u vagrant sh -c 'ibmcloud config --usage-stats-collect false'
-    sudo -H -u vagrant sh -c 'ibmcloud cf install'
+    sudo -H -u vagrant sh -c 'ic cf install --version 6.46.1'
     sudo -H -u vagrant sh -c "echo 'source <(kubectl completion bash)' >> ~/.bashrc"
     sudo -H -u vagrant sh -c "echo alias ic=/usr/local/bin/ibmcloud >> ~/.bash_aliases"
     echo "\n"


### PR DESCRIPTION
Updated Vagrant file to install version 6.46.1 of IBM CLI instead.
Push the app to the cloud correctly without the Log 404 Errors appearing.